### PR TITLE
Add Asus ZenFone 2 Laser Z00L

### DIFF
--- a/dot.devices
+++ b/dot.devices
@@ -17,3 +17,4 @@ bacon userdebug
 rolex userdebug
 kenzo userdebug
 kiwi userdebug
+Z00L userdebug


### PR DESCRIPTION
Add Asus ZenFone 2 Laser (Z00L) for official support